### PR TITLE
Fixes for V2.1

### DIFF
--- a/nheqminer/crypto/verus_clhash.cpp
+++ b/nheqminer/crypto/verus_clhash.cpp
@@ -349,7 +349,7 @@ void cpu_verushash::solve_verus_v2_opt(CBlockHeader &bh,
     const int keyrefreshsize = vclh.keyrefreshsize(); // number of 256 bit blocks
 
 	bh.nSolution = std::vector<unsigned char>(1344);
-	bh.nSolution[0] = 3; // latest VerusHash 2.0 solution version
+	bh.nSolution[0] = 3; // latest VerusHash 2.1 solution version
 
 	// prepare the hash state
 	vhw.Reset();
@@ -445,7 +445,8 @@ void cpu_verushash::solve_verus_v2_opt(CBlockHeader &bh,
 
 		// run verusclhash on the buffer
         //const uint64_t intermediate = vclh(curBuf, hashKey, pMoveScratch);
-        __m128i  acc = __verusclmulwithoutreduction64alignedrepeat(hashKey, (const __m128i *)curBuf, vclh.keyMask, pMoveScratch);
+        __m128i  acc = (*vclh.verusinternalclhashfunction)(hashKey, (const __m128i *)curBuf, vclh.keyMask, pMoveScratch);
+
         acc = _mm_xor_si128(acc, lazyLengthHash(1024, 64));
 		const uint64_t intermediate = precompReduction64(acc);
 

--- a/nheqminer/hash.h
+++ b/nheqminer/hash.h
@@ -295,9 +295,9 @@ uint256 SerializeVerusHashV2(const T& obj, int nType=SER_GETHASH, int nVersion=P
  *  a carryless multiply-based hash as fill for the unused space.
  */
 template<typename T>
-uint256 SerializeVerusHashV2b(const T& obj, verusclhasher *vlch=NULL, int nType=SER_GETHASH, int nVersion=PROTOCOL_VERSION)
+uint256 SerializeVerusHashV2b(const T& obj, int nType=SER_GETHASH, int nVersion=PROTOCOL_VERSION, int solVersion=SOLUTION_VERUSHHASH_V2_1)
 {
-    CVerusHashV2bWriter ss(nType, nVersion);
+    CVerusHashV2bWriter ss(nType, nVersion, solVersion);
     ss << obj;
     return ss.GetHash();
 }


### PR DESCRIPTION
Make sure SOLUTION_VERUSHHASH_V2_1 is default for CVerusHashV2bWriter
Make sure to use proper verusclhasher internal hash function in solve_verus_v2_opt